### PR TITLE
use relative imports

### DIFF
--- a/assets/fonts/roboto.css
+++ b/assets/fonts/roboto.css
@@ -2,36 +2,36 @@
   font-family: 'Roboto';
   font-style: italic;
   font-weight: 400;
-  src: local('Roboto Italic'), local('Roboto-Italic'), url(/fonts/roboto-italic_400.ttf) format('truetype');
+  src: local('Roboto Italic'), local('Roboto-Italic'), url(./roboto-italic_400.ttf) format('truetype');
 }
 @font-face {
   font-family: 'Roboto';
   font-style: italic;
   font-weight: 500;
-  src: local('Roboto Medium Italic'), local('Roboto-MediumItalic'), url(/fonts/roboto-italic_500.ttf) format('truetype');
+  src: local('Roboto Medium Italic'), local('Roboto-MediumItalic'), url(./roboto-italic_500.ttf) format('truetype');
 }
 @font-face {
   font-family: 'Roboto';
   font-style: normal;
   font-weight: 400;
-  src: local('Roboto'), local('Roboto-Regular'), url(/fonts/roboto_400.ttf) format('truetype');
+  src: local('Roboto'), local('Roboto-Regular'), url(./roboto_400.ttf) format('truetype');
 }
 @font-face {
   font-family: 'Roboto';
   font-style: normal;
   font-weight: 500;
-  src: local('Roboto Medium'), local('Roboto-Medium'), url(/fonts/roboto_500.ttf) format('truetype');
+  src: local('Roboto Medium'), local('Roboto-Medium'), url(./roboto_500.ttf) format('truetype');
 }
 @font-face {
   font-family: 'Roboto';
   font-style: italic;
   font-weight: 300;
-  src: local('Roboto Light Italic'), local('Roboto-LightItalic'), url(/fonts/roboto-italic_300.ttf) format('truetype');
+  src: local('Roboto Light Italic'), local('Roboto-LightItalic'), url(./roboto-italic_300.ttf) format('truetype');
 }
 @font-face {
   font-family: 'Roboto';
   font-style: normal;
   font-weight: 300;
-  src: local('Roboto Light'), local('Roboto-Light'), url(/fonts/roboto_300.ttf) format('truetype');
+  src: local('Roboto Light'), local('Roboto-Light'), url(./roboto_300.ttf) format('truetype');
 }
 

--- a/assets/scss/main.scss
+++ b/assets/scss/main.scss
@@ -1,9 +1,9 @@
 @import 'libs/vars';
 @import 'libs/functions';
 @import 'libs/mixins';
-@import url("/css/font-awesome.min.css");
-@import url("/fonts/roboto.css");
-@import url("/css/default-spacestatus.css");
+@import url("./font-awesome.min.css");
+@import url("../fonts/roboto.css");
+@import url("./default-spacestatus.css");
 @import "libs/skel";
 @import 'parts/startpage';
 

--- a/assets/scss/parts/_banner.scss
+++ b/assets/scss/parts/_banner.scss
@@ -2,7 +2,7 @@
 #banner {
   background-attachment: fixed;
   background-color: _palette(accent2);
-  background-image: url('/images/banner.jpg');
+  background-image: url('../images/banner.jpg');
   background-position: center center;
   background-size: cover;
   box-shadow: 0 0.25em 0.5em 0 rgba(0, 0, 0, 0.25);


### PR DESCRIPTION
so wie bereits bei dem letzten PR für die Übersetzungen ermöglichen es die relativen Imports die Webseite als Unterseite zu betreiben.
Hier mal ein Beispiel wie das dann aussieht (nur die import dann noch richtig)
https://release.maxbachmann.de/staging-test/
So kann einfach jeder branch als Unterseite zB nach dem Schema ```toolbox-bodensee.de/staging-\<branch name>``` dargestellt werden.

Das selbe Problem gibt es auch noch an einigen anderen Stellen die ich dann ebenfalls ausmerzen werde